### PR TITLE
fix: WARNING: `exec` will be deprecated in v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,21 @@ Add this to your `keymap.toml`:
 ```toml
 [[manager.prepend_keymap]]
 on = [ "u", "a" ]
-exec = "plugin bookmarks-persistence --args=save"
+run = "plugin bookmarks-persistence --args=save"
 desc = "Save current position as a bookmark"
 
 [[manager.prepend_keymap]]
 on = [ "u", "g" ]
-exec = "plugin bookmarks-persistence --args=jump"
+run = "plugin bookmarks-persistence --args=jump"
 desc = "Jump to a bookmark"
 
 [[manager.prepend_keymap]]
 on = [ "u", "d" ]
-exec = "plugin bookmarks-persistence --args=delete"
+run = "plugin bookmarks-persistence --args=delete"
 desc = "Delete a bookmark"
 
 [[manager.prepend_keymap]]
 on = [ "u", "D" ]
-exec = "plugin bookmarks-persistence --args=delete_all"
+run = "plugin bookmarks-persistence --args=delete_all"
 desc = "Delete all bookmarks"
 ```


### PR DESCRIPTION
This "fixes" the following error when running with `Yazi 0.2.5 (VERGEN_IDEMPOTENT_OUTPUT 1980-01-01)`:

```bash

WARNING: `exec` will be deprecated in the next major version v0.3 and
replaced by `run`.

Please replace all `exec = ...` with `run = ...`, in your `yazi.toml`
and `keymap.toml`.

---
Add `disable_exec_warn = true` to your `yazi.toml` under `[headsup]` to
suppress this warning
```

All I did was change the recommended `keymap.toml` config from the README. This PR really is no big improvement in any other way. 